### PR TITLE
Add loft.trade to the exchange list

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ So, let's do it!
 [River Financial](https://river.com/) | YES | October 2019 | :zap: | [Twitter](https://twitter.com/AndrewBenson/status/1354131122980982785) | n.d. | ln.river.com
 [VBTC Vietnam](https://vbtc.exchange/) | YES | January 2021 | :zap: | [Twitter](https://twitter.com/VBTC_Vietnam/status/1353564136702005248) | n.d.
 [FixedFloat](https://fixedfloat.com/) | YES | February 2019 | :zap: | [blog](https://fixedfloat.com/blog/currency/lightning-network) | n.d. | [Link](https://1ml.com/node/037f990e61acee8a7697966afd29dd88f3b1f8a7b14d625c4f8742bd952003a590) fixedfloat.com
+[LOFT](https://loft.trade/) | YES | February 2021 | :zap: | [Twitter](https://twitter.com/LoftTrade/status/1370047636728844288) | n.d. | n.a
 
 I invite the representatives of the exchanges to signal their support to Lightning Network also in this repo.
 


### PR DESCRIPTION
The title is self explanatory but I'd like to add that __loft.trade__ isn't actually an exchange but more a trading platform, it does not exchange fiat <--> btc, so i'll leave it to @theDavidCoen judgement whether he wants to merge the PR.