### PR TITLE
Add a 'poop' exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ So, let's do it!
 [Coinfinity](https://coinfinity.co) | YES (JUN-2023) | :hourglass_flowing_sand: | [Twitter](https://twitter.com/coinfinity/status/1663870230454476801) | n.a. | [Link](https://amboss.space/node/02d4531a2f2e6e5a9033d37d548cff4834a3898e74c3abe1985b493c42ebbd707d) coinfinity.co | :broken_heart: YES | n.a
 [Ripio](https://www.ripio.com/) | **YES** (AUG-2023) | :zap: | [Twitter](https://x.com/ripioBR/status/1669807881330348033?s=20) | n.a. | [Link](https://amboss.space/node/03831262b0cb086ba6f2360a36757e4283347f3f67f01d6f24f54c3eee841e29d6) Ripio 🐖 | :broken_heart: YES | n.a
 [StealthEX](https://stealthex.io/) | **YES** (NOV-2023) | :zap: | [Twitter](https://twitter.com/VisionaryFinanc/status/1722840266812371377) | n.a. | n.a. | :green_heart: NO | n.a.
+ ------------ | --------- | ---- | -------- | -------- | -------- | -------- | -----
+[Verse](https://exchange.bitcoin.com/) | **NO** | :poop: | n.a. | n.a. | n.a. | n.a. | n.a.
 
 I invite the representatives of the exchanges to signal their support to Lightning Network also in this repo.
 


### PR DESCRIPTION
The 'poop' emoticon mentioned in the Legend wasn't actually being used by any row of the table. This fixes it. Verse is a bitcoin exchange that is part of the 'bitcoin.com' conglomerate, which is an industry attack on bitcoin because they are infringing bitcoin trademarks by purporting BCash as the real bitcoin. Therefore, one can easily assume that they won't ever support Lightning (BCash supporters are always bashing Lightning, spreading lies about it, such as saying that it's a custodial technology, or just IOUs, etc). For the record, BCash doesn't support LN (it can't, as it doesn't have SegWit, therefore it is prone to transaction malleability).

More info about Verse:
https://cryptoslate.com/nobody-seems-to-trust-roger-vers-newly-announced-cryptocurrency-exchange/